### PR TITLE
Fix empty slides filling div with line breaks.

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,12 +24,13 @@ function processProPresenterMessage(message) {
     if (message['acn'] == "fv") {
         if (message['ary'][0]['txt'] != undefined && message['ary'][0]['acn'] === 'cs') {
             var text = '';
-	
+
             // check slide note for noText keyword.  If noText is defined dont step into this IF
             if (typeof message['ary'][2] !== 'undefined' && message['ary'][2]['txt'] !== config["noText"]) {
+                // remove newlines at beginning and end of line
                 // replace carriage return \r and linefeed \n with <br> global
-                text = message['ary'][0]['txt'].replace(/\r\n|\n|\r/g, '<br />');
-	
+                text = message['ary'][0]['txt'].replace(/^\s+|\s+$/g, "").replace(/\r\n|\n|\r/g, '<br />');
+
                 // if fading is true and repeated text is true
                 if (prev_text !== text || config['fade_repeated_text']) {
                     // if fading is true

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -13,25 +13,26 @@ I use their database of information on a regular bases, and it can help you get 
     padding: 0;
     margin: 0;
     color: white;
-    /*
     font-size: 10px;
     font-family: Montserrat, Arial, Helvetica, sans-serif;
     text-transform: uppercase;
-    */
-    font-size: 18px;
-    font-family: Brandon Grotesque, Montserrat, Arial, Helvetica, sans-serif;
     text-align: center;
     overflow: hidden;
 }
 
 #cs {
     width: 100%;
-    /*padding: 0.5em 0;*/
-    font-size: 5em;
+    padding: 0.5em 0;
+    font-size: 3em;
     line-height: 1.6em;
     letter-spacing: 1px;
     position: absolute;
     bottom: 0;
     text-shadow: 3px 3px 4px black;
-    background-color: rgba(0, 0, 0, 0.6);
+	background: rgba(0, 0, 0, 0.8);
+}
+
+/* This hides the div when empty to remove those ugly black bars. */
+#cs:empty {
+    visibility: hidden;
 }


### PR DESCRIPTION
Thank you for writing this version of ProPresenter-OBS, we have used it for a few years now.

Our ProPresenter would send additional newlines to the beginning and end of the message, causing the margins to be larger, and empty slides to still appear on the screen as a empty region at the base of our stream.